### PR TITLE
Bug fix - blocked input field

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
                 <div class="activities__input-description-block">
                   <label class="activities__input-description" for="description">What would you like to accomplish during this time?</label>
                   <input id="description-input" title="description" class="activities__text-field" type="text" name="description" placeholder="">
-                  <div class="activities__input-description__warning --hidden"><img class="activities__input-description__warning-icon" src="./assets/warning.svg"> A description is required.</div>
+                  <div class="activities__input-description__warning --hidden"><img class="activities__input-description__warning-icon" src="./assets/warning.svg">A description is required.</div>
                 </div>
               </div>
               <div id="minutes-seconds-block" class="activities__input-block">

--- a/main.js
+++ b/main.js
@@ -6,9 +6,10 @@ var dataModel = {
   seconds: "",
   completed: false,
   id: "",
-  startTimePlaceholder: "05:00",
 }
-var newCard = new Activity(dataModel)
+
+var pastActivityData = [];
+
 // EVENT LISTENERS 👇
 document.querySelector(".activities__icons-section").addEventListener("click", function(event) {
   if (event.target.id !== undefined || event.target.id !== null || event.target.id !== "") {
@@ -25,9 +26,6 @@ document.querySelector(".activities__select-category").addEventListener('click',
 });
 
 document.querySelector("#minutes-seconds-block").addEventListener("keypress", function(event) {
-  // console.log(event);
-  // console.log(event.keyCode);
-  // console.log(event.target.value);
   var validKeys = [8, 9, 13, 18, 92, 93];  //  keys like tab, etc
   if (event.keyCode >= 48 && event.keyCode <= 57 || validKeys.includes(event.keyCode) === true) {   // TODO future note in readme that this iterates 2x with each additional number
     event.currentTarget.addEventListener("keyup", function(event) {
@@ -97,7 +95,7 @@ function insertTimer() {
   `
   <div class="activities__timer">
     <div class="activities__timer__description">${dataModel.description}</div>
-    <div class="activities__timer__clock">${dataModel.startTimePlaceholder}</div>
+    <div class="activities__timer__clock">CHANGETHIS</div>
     <svg class="activities__timer__svg activities__timer--${dataModel.category}" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
       <g class="activities__timer__circle">
         <circle class="activities__timer__path-elapsed" cx="50" cy="50" r="45" />
@@ -126,31 +124,32 @@ function insertTimer() {
 
 function startTimer() {
   var totalTime = Number(`${dataModel.minutes}` * 60) + Number(`${dataModel.seconds}`);
-  var minutes;
-  var seconds;
-  var timeLeft = totalTime;
-  dataModel.startTimePlaceholder = minutes + ":" + seconds;
   document.querySelector(".activities__timer__button__text").innerText = ""
-  setInterval(function () {
+  countDown(totalTime);
+}
+
+function countDown(totalTime) {
+  var timeLeft = totalTime;
+  setInterval(function() {
     minutes = parseInt(timeLeft / 60, 10);
     seconds = parseInt(timeLeft % 60, 10);
     minutes = minutes < 10 ? "0" + minutes : minutes;
     seconds = seconds < 10 ? "0" + seconds : seconds;
     document.querySelector(".activities__timer__clock").textContent = minutes + ":" + seconds;
     if (timeLeft-- <= 0) {
-      dataModel.completed = true;
-      document.querySelector(".activities__timer__button__text").textContent = "COMPLETE!";
-      document.querySelector(".activities__timer__clock").textContent = "00:00";
-      document.querySelector('.activities__timer__log-button').classList.remove("--hidden");
-      document.querySelector('.activities__timer__button__text').classList.add(".activities__timer__button__text--nopointer");
+      timerComplete();
     }
     setCircleDasharray((timeLeft / totalTime));
   }, 1000);
 }
-// // Divides time left by the defined time limit.
-// function calculateTimeFraction() {
-//   return timeLeft / totalTime;
-// }
+
+function timerComplete() {
+  dataModel.completed = true;
+  document.querySelector(".activities__timer__button__text").textContent = "COMPLETE!";
+  document.querySelector(".activities__timer__clock").textContent = "00:00";
+  document.querySelector('.activities__timer__log-button').classList.remove("--hidden");
+  document.querySelector('.activities__timer__button__text').classList.add(".activities__timer__button__text--nopointer");
+}
 
 // Update the dasharray value as time passes, starting with 283
 function setCircleDasharray(timeFraction) {

--- a/styles.css
+++ b/styles.css
@@ -154,6 +154,7 @@ html {
 
 .activities__input-description__warning-icon {
   height: 15px;
+  padding-right: 5px;
 }
 
 .study-icon {

--- a/styles.css
+++ b/styles.css
@@ -144,8 +144,9 @@ html {
   color: #EFB7EC;
   display: block;
   align-self: flex-start;
-  padding-top: 70px;
+  margin-top: 70px;
   position: absolute;
+  cursor: default;
 }
 
 .activities__text-field--warning {


### PR DESCRIPTION
The empty description field warning was blocking the input from being accessed due to `padding-top`.

![Screen Shot 2020-09-14 at 10 33 49 AM](https://user-images.githubusercontent.com/66697338/93113784-e6625800-f676-11ea-84f6-b9f1b7e869b6.png)

**FIX** Kept the pixel count from `padding` but applied it to `margin-top`, as well as default `cursor` behavior, to allow clicking into input field after warning pops (.css ln 147, 149).

![Screen Shot 2020-09-14 at 10 35 18 AM](https://user-images.githubusercontent.com/66697338/93113974-37724c00-f677-11ea-9d87-aa2742ed95f9.png)


